### PR TITLE
增加：获取SIM卡国家代码检测

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,6 +88,13 @@ function getPhoneState() {
         return temp;
     }
 
+    //SIM卡国家代码
+    TelephonyManager.getSimCountryIso.overload().implementation = function () {
+        var temp = this.getSimCountryIso();
+        alertSend("获取SIM卡国家代码", "获取SIM卡国家代码为(String): " + temp);
+        return temp;
+    }
+
     //imsi/iccid
     TelephonyManager.getSimSerialNumber.overload('int').implementation = function (p) {
         var temp = this.getSimSerialNumber(p);


### PR DESCRIPTION
部分合规检测会检测这个接口，在错误的场合调用后就会判定合规不通过，故需要加上检测。

因为能力所限，还不知道其他合规检测还会检测什么sim卡信息接口，建议也加上其他接口。